### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,19 @@ __pycache__/
 .coverage
 .pytest_cache/
 .pyenv/
+venv/
+env/
+.venv/
+.env/
+
+# Rust
+target/
+Cargo.lock
+
+# Node.js
+node_modules/
+dist/
+build/ # This might be too generic, but is common for JS build tools
+*.tgz
+package-lock.json
+yarn.lock


### PR DESCRIPTION
Automatically updated .gitignore to exclude common build artifacts and dependencies for Python, Rust, and Node.js based on the files present in the repository.